### PR TITLE
fix typo `loaded_deno_cache`

### DIFF
--- a/plugin/deno-cache.vim
+++ b/plugin/deno-cache.vim
@@ -1,7 +1,7 @@
 if exists('g:loaded_deno_cache')
   finish
 endif
-let g:loaded_cache = 1
+let g:loaded_deno_cache = 1
 
 augroup deno_cache_plugin
   autocmd!


### PR DESCRIPTION
I found a typo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Renamed a global variable to improve clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->